### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/webdeveric/esbuild-plugin-environment.git"
+    "url": "git+https://github.com/webdeveric/esbuild-plugin-environment.git"
   },
   "bugs": {
     "url": "https://github.com/webdeveric/esbuild-plugin-environment/issues"


### PR DESCRIPTION
## Summary

- replace the package repository URL with a public HTTPS GitHub URL
- keep the existing repository type, homepage, bugs URL, and package exports unchanged

## Why

The package metadata currently points at the repository through a `git+ssh://git@github.com/...` URL. Using the public HTTPS form makes the npm metadata usable in environments that do not have GitHub SSH configured.

## Validation

- `node -e "const p=require('./package.json'); if(p.repository.url!=='git+https://github.com/webdeveric/esbuild-plugin-environment.git') throw new Error(p.repository.url); console.log('metadata ok')"`
- `git diff --check`
- `pnpm install --ignore-scripts --frozen-lockfile`
- `pnpm test` (1 file, 12 tests)
- `pnpm build`
